### PR TITLE
Range check example (broken)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 mod fibonacci;
 mod is_zero;
+mod range_check;

--- a/src/range_check.rs
+++ b/src/range_check.rs
@@ -1,0 +1,1 @@
+mod example1;

--- a/src/range_check.rs
+++ b/src/range_check.rs
@@ -1,1 +1,2 @@
 mod example1;
+mod example2;

--- a/src/range_check.rs
+++ b/src/range_check.rs
@@ -1,2 +1,3 @@
 mod example1;
 mod example2;
+mod example3_broken;

--- a/src/range_check/example1.rs
+++ b/src/range_check/example1.rs
@@ -1,0 +1,173 @@
+use std::marker::PhantomData;
+
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{AssignedCell, Layouter, Value},
+    plonk::{Advice, Assigned, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
+    poly::Rotation,
+};
+
+/// This helper checks that the value witnessed in a given cell is within a given range.
+///
+///        value     |    q_range_check
+///       ------------------------------
+///          v       |         1
+///
+
+#[derive(Debug, Clone)]
+/// A range-constrained value in the circuit produced by the RangeCheckConfig.
+struct RangeConstrained<F: FieldExt, const RANGE: usize>(AssignedCell<Assigned<F>, F>);
+
+#[derive(Debug, Clone)]
+struct RangeCheckConfig<F: FieldExt, const RANGE: usize> {
+    value: Column<Advice>,
+    q_range_check: Selector,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt, const RANGE: usize> RangeCheckConfig<F, RANGE> {
+    pub fn configure(meta: &mut ConstraintSystem<F>, value: Column<Advice>) -> Self {
+        let q_range_check = meta.selector();
+
+        meta.create_gate("range check", |meta| {
+            //        value     |    q_range_check
+            //       ------------------------------
+            //          v       |         1
+
+            let q = meta.query_selector(q_range_check);
+            let value = meta.query_advice(value, Rotation::cur());
+
+            // Given a range R and a value v, returns the expression
+            // (v) * (1 - v) * (2 - v) * ... * (R - 1 - v)
+            let range_check = |range: usize, value: Expression<F>| {
+                (0..range).fold(value.clone(), |expr, i| {
+                    expr * (Expression::Constant(F::from(i as u64)) - value.clone())
+                })
+            };
+
+            Constraints::with_selector(q, [("range check", range_check(RANGE, value))])
+        });
+
+        Self {
+            q_range_check,
+            value,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn assign(
+        &self,
+        mut layouter: impl Layouter<F>,
+        value: Value<Assigned<F>>,
+    ) -> Result<RangeConstrained<F, RANGE>, Error> {
+        layouter.assign_region(
+            || "Assign value",
+            |mut region| {
+                let offset = 0;
+
+                // Enable q_range_check
+                self.q_range_check.enable(&mut region, offset)?;
+
+                // Assign value
+                region
+                    .assign_advice(|| "value", self.value, offset, || value)
+                    .map(RangeConstrained)
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use halo2_proofs::{
+        circuit::floor_planner::V1,
+        dev::{FailureLocation, MockProver, VerifyFailure},
+        pasta::Fp,
+        plonk::{Any, Circuit},
+    };
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MyCircuit<F: FieldExt, const RANGE: usize> {
+        value: Value<Assigned<F>>,
+    }
+
+    impl<F: FieldExt, const RANGE: usize> Circuit<F> for MyCircuit<F, RANGE> {
+        type Config = RangeCheckConfig<F, RANGE>;
+        type FloorPlanner = V1;
+
+        fn without_witnesses(&self) -> Self {
+            Self::default()
+        }
+
+        fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            let value = meta.advice_column();
+            RangeCheckConfig::configure(meta, value)
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            config.assign(layouter.namespace(|| "Assign value"), self.value)?;
+
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_range_check_1() {
+        let k = 4;
+        const RANGE: usize = 8; // 3-bit value
+
+        // Successful cases
+        for i in 0..RANGE {
+            let circuit = MyCircuit::<Fp, RANGE> {
+                value: Value::known(Fp::from(i as u64).into()),
+            };
+
+            let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+            prover.assert_satisfied();
+        }
+
+        // Out-of-range `value = 8`
+        {
+            let circuit = MyCircuit::<Fp, RANGE> {
+                value: Value::known(Fp::from(RANGE as u64).into()),
+            };
+            let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+            assert_eq!(
+                prover.verify(),
+                Err(vec![VerifyFailure::ConstraintNotSatisfied {
+                    constraint: ((0, "range check").into(), 0, "range check").into(),
+                    location: FailureLocation::InRegion {
+                        region: (0, "Assign value").into(),
+                        offset: 0
+                    },
+                    cell_values: vec![(((Any::Advice, 0).into(), 0).into(), "0x8".to_string())]
+                }])
+            );
+        }
+    }
+
+    #[cfg(feature = "dev-graph")]
+    #[test]
+    fn print_range_check_1() {
+        use plotters::prelude::*;
+
+        let root = BitMapBackend::new("range-check-1-layout.png", (1024, 3096)).into_drawing_area();
+        root.fill(&WHITE).unwrap();
+        let root = root
+            .titled("Range Check 1 Layout", ("sans-serif", 60))
+            .unwrap();
+
+        let circuit = MyCircuit::<Fp, 8> {
+            value: Value::unknown(),
+        };
+        halo2_proofs::dev::CircuitLayout::default()
+            .render(3, &circuit, &root)
+            .unwrap();
+    }
+}

--- a/src/range_check/example2.rs
+++ b/src/range_check/example2.rs
@@ -1,0 +1,237 @@
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{AssignedCell, Layouter, Value},
+    plonk::{Advice, Assigned, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
+    poly::Rotation,
+};
+
+mod table;
+use table::*;
+
+/// This helper checks that the value witnessed in a given cell is within a given range.
+/// Depending on the range, this helper uses either a range-check expression (for small ranges),
+/// or a lookup (for large ranges).
+///
+///        value     |    q_range_check    |   q_lookup  |  table_value  |
+///       ----------------------------------------------------------------
+///          v_0     |         1           |      0      |       0       |
+///          v_1     |         0           |      1      |       1       |
+///
+/// We use a K-bit lookup table, that is tagged 1..=K, where the tag `i` marks an `i`-bit value.
+///
+
+#[derive(Debug, Clone)]
+/// A range-constrained value in the circuit produced by the RangeCheckConfig.
+struct RangeConstrained<F: FieldExt, const RANGE: usize>(AssignedCell<Assigned<F>, F>);
+
+#[derive(Debug, Clone)]
+struct RangeCheckConfig<F: FieldExt, const RANGE: usize, const LOOKUP_RANGE: usize> {
+    q_range_check: Selector,
+    q_lookup: Selector,
+    value: Column<Advice>,
+    table: RangeTableConfig<F, LOOKUP_RANGE>,
+}
+
+impl<F: FieldExt, const RANGE: usize, const LOOKUP_RANGE: usize>
+    RangeCheckConfig<F, RANGE, LOOKUP_RANGE>
+{
+    pub fn configure(meta: &mut ConstraintSystem<F>, value: Column<Advice>) -> Self {
+        let q_range_check = meta.selector();
+        let q_lookup = meta.complex_selector();
+        let table = RangeTableConfig::configure(meta);
+
+        meta.create_gate("range check", |meta| {
+            //        value     |    q_range_check
+            //       ------------------------------
+            //          v       |         1
+
+            let q = meta.query_selector(q_range_check);
+            let value = meta.query_advice(value, Rotation::cur());
+
+            // Given a range R and a value v, returns the expression
+            // (v) * (1 - v) * (2 - v) * ... * (R - 1 - v)
+            let range_check = |range: usize, value: Expression<F>| {
+                (0..range).fold(value.clone(), |expr, i| {
+                    expr * (Expression::Constant(F::from(i as u64)) - value.clone())
+                })
+            };
+
+            Constraints::with_selector(q, [("range check", range_check(RANGE, value))])
+        });
+
+        meta.lookup(|meta| {
+            let q_lookup = meta.query_selector(q_lookup);
+            let value = meta.query_advice(value, Rotation::cur());
+
+            vec![(q_lookup * value, table.value)]
+        });
+
+        Self {
+            q_range_check,
+            q_lookup,
+            value,
+            table,
+        }
+    }
+
+    pub fn assign_simple(
+        &self,
+        mut layouter: impl Layouter<F>,
+        value: Value<Assigned<F>>,
+    ) -> Result<RangeConstrained<F, RANGE>, Error> {
+        layouter.assign_region(
+            || "Assign value for simple range check",
+            |mut region| {
+                let offset = 0;
+
+                // Enable q_range_check
+                self.q_range_check.enable(&mut region, offset)?;
+
+                // Assign value
+                region
+                    .assign_advice(|| "value", self.value, offset, || value)
+                    .map(RangeConstrained)
+            },
+        )
+    }
+
+    pub fn assign_lookup(
+        &self,
+        mut layouter: impl Layouter<F>,
+        value: Value<Assigned<F>>,
+    ) -> Result<RangeConstrained<F, RANGE>, Error> {
+        layouter.assign_region(
+            || "Assign value for lookup range check",
+            |mut region| {
+                let offset = 0;
+
+                // Enable q_lookup
+                self.q_lookup.enable(&mut region, offset)?;
+
+                // Assign value
+                region
+                    .assign_advice(|| "value", self.value, offset, || value)
+                    .map(RangeConstrained)
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use halo2_proofs::{
+        circuit::floor_planner::V1,
+        dev::{FailureLocation, MockProver, VerifyFailure},
+        pasta::Fp,
+        plonk::{Any, Circuit},
+    };
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MyCircuit<F: FieldExt, const RANGE: usize, const LOOKUP_RANGE: usize> {
+        value: Value<Assigned<F>>,
+        lookup_value: Value<Assigned<F>>,
+    }
+
+    impl<F: FieldExt, const RANGE: usize, const LOOKUP_RANGE: usize> Circuit<F>
+        for MyCircuit<F, RANGE, LOOKUP_RANGE>
+    {
+        type Config = RangeCheckConfig<F, RANGE, LOOKUP_RANGE>;
+        type FloorPlanner = V1;
+
+        fn without_witnesses(&self) -> Self {
+            Self::default()
+        }
+
+        fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            let value = meta.advice_column();
+            RangeCheckConfig::configure(meta, value)
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            config.table.load(&mut layouter)?;
+
+            config.assign_simple(layouter.namespace(|| "Assign simple value"), self.value)?;
+            config.assign_lookup(
+                layouter.namespace(|| "Assign lookup value"),
+                self.lookup_value,
+            )?;
+
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_range_check_2() {
+        let k = 9;
+        const RANGE: usize = 8; // 3-bit value
+        const LOOKUP_RANGE: usize = 256; // 8-bit value
+
+        // Successful cases
+        for i in 0..RANGE {
+            for j in 0..LOOKUP_RANGE {
+                let circuit = MyCircuit::<Fp, RANGE, LOOKUP_RANGE> {
+                    value: Value::known(Fp::from(i as u64).into()),
+                    lookup_value: Value::known(Fp::from(j as u64).into()),
+                };
+
+                let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+                prover.assert_satisfied();
+            }
+        }
+
+        // Out-of-range `value = 8`, `lookup_value = 256`
+        {
+            let circuit = MyCircuit::<Fp, RANGE, LOOKUP_RANGE> {
+                value: Value::known(Fp::from(RANGE as u64).into()),
+                lookup_value: Value::known(Fp::from(LOOKUP_RANGE as u64).into()),
+            };
+            let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+            assert_eq!(
+                prover.verify(),
+                Err(vec![
+                    VerifyFailure::ConstraintNotSatisfied {
+                        constraint: ((0, "range check").into(), 0, "range check").into(),
+                        location: FailureLocation::InRegion {
+                            region: (1, "Assign value for simple range check").into(),
+                            offset: 0
+                        },
+                        cell_values: vec![(((Any::Advice, 0).into(), 0).into(), "0x8".to_string())]
+                    },
+                    VerifyFailure::Lookup {
+                        lookup_index: 0,
+                        location: FailureLocation::InRegion {
+                            region: (2, "Assign value for lookup range check").into(),
+                            offset: 0
+                        }
+                    }
+                ])
+            );
+        }
+    }
+
+    #[cfg(feature = "dev-graph")]
+    #[test]
+    fn print_range_check_2() {
+        use plotters::prelude::*;
+
+        let root = BitMapBackend::new("range-check-2-layout.png", (1024, 3096)).into_drawing_area();
+        root.fill(&WHITE).unwrap();
+        let root = root
+            .titled("Range Check 2 Layout", ("sans-serif", 60))
+            .unwrap();
+
+        let circuit = MyCircuit::<Fp, 8, 256> {
+            value: Value::unknown(),
+            lookup_value: Value::unknown(),
+        };
+        halo2_proofs::dev::CircuitLayout::default()
+            .render(9, &circuit, &root)
+            .unwrap();
+    }
+}

--- a/src/range_check/example2/table.rs
+++ b/src/range_check/example2/table.rs
@@ -1,0 +1,45 @@
+use std::marker::PhantomData;
+
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{Layouter, Value},
+    plonk::{ConstraintSystem, Error, TableColumn},
+};
+
+/// A lookup table of values from 0..RANGE.
+#[derive(Debug, Clone)]
+pub(super) struct RangeTableConfig<F: FieldExt, const RANGE: usize> {
+    pub(super) value: TableColumn,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt, const RANGE: usize> RangeTableConfig<F, RANGE> {
+    pub(super) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+        let value = meta.lookup_table_column();
+
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(super) fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+        layouter.assign_table(
+            || "load range-check table",
+            |mut table| {
+                let mut offset = 0;
+                for value in 0..RANGE {
+                    table.assign_cell(
+                        || "num_bits",
+                        self.value,
+                        offset,
+                        || Value::known(F::from(value as u64)),
+                    )?;
+                    offset += 1;
+                }
+
+                Ok(())
+            },
+        )
+    }
+}

--- a/src/range_check/example3_broken.rs
+++ b/src/range_check/example3_broken.rs
@@ -1,0 +1,200 @@
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{AssignedCell, Layouter, Value},
+    plonk::{
+        Advice, Assigned, Column, ConstraintSystem, Constraints, Error, Expression, Selector,
+        TableColumn,
+    },
+    poly::Rotation,
+};
+
+mod table;
+use table::*;
+
+/// This helper uses a lookup table to check that the value witnessed in a given cell is
+/// within a given range.
+///
+/// The lookup table is tagged by `num_bits` to give a strict range check.
+///
+///        value     |   q_lookup  |  table_num_bits  |  table_value  |
+///       -------------------------------------------------------------
+///          v_0     |      0      |        1         |       0       |
+///          v_1     |      1      |        1         |       1       |
+///          ...     |     ...     |        2         |       2       |
+///          ...     |     ...     |        2         |       3       |
+///          ...     |     ...     |        2         |       4       |
+///
+/// We use a K-bit lookup table, that is tagged 1..=K, where the tag `i` marks an `i`-bit value.
+///
+
+#[derive(Debug, Clone)]
+/// A range-constrained value in the circuit produced by the RangeCheckConfig.
+struct RangeConstrained<F: FieldExt> {
+    num_bits: AssignedCell<Assigned<F>, F>,
+    assigned_cell: AssignedCell<Assigned<F>, F>,
+}
+
+#[derive(Debug, Clone)]
+struct RangeCheckConfig<F: FieldExt, const NUM_BITS: usize, const RANGE: usize> {
+    q_lookup: Selector,
+    num_bits: Column<Advice>,
+    value: Column<Advice>,
+    table: RangeTableConfig<F, NUM_BITS, RANGE>,
+}
+
+impl<F: FieldExt, const NUM_BITS: usize, const RANGE: usize> RangeCheckConfig<F, NUM_BITS, RANGE> {
+    pub fn configure(
+        meta: &mut ConstraintSystem<F>,
+        num_bits: Column<Advice>,
+        value: Column<Advice>,
+    ) -> Self {
+        let q_lookup = meta.complex_selector();
+        let table = RangeTableConfig::configure(meta);
+
+        meta.lookup(|meta| {
+            let q_lookup = meta.query_selector(q_lookup);
+            let num_bits = meta.query_advice(num_bits, Rotation::cur());
+            let value = meta.query_advice(value, Rotation::cur());
+
+            // THIS IS BROKEN!!!!!!
+            // Hint: consider the case where q_lookup = 0. What are our input expressions to the lookup argument then?
+            vec![
+                (q_lookup.clone() * num_bits, table.num_bits),
+                (q_lookup * value, table.value),
+            ]
+        });
+
+        Self {
+            q_lookup,
+            num_bits,
+            value,
+            table,
+        }
+    }
+
+    pub fn assign(
+        &self,
+        mut layouter: impl Layouter<F>,
+        num_bits: Value<u8>,
+        value: Value<Assigned<F>>,
+    ) -> Result<RangeConstrained<F>, Error> {
+        layouter.assign_region(
+            || "Assign value",
+            |mut region| {
+                let offset = 0;
+
+                // Enable q_lookup
+                self.q_lookup.enable(&mut region, offset)?;
+
+                // Assign num_bits
+                let num_bits = num_bits.map(|v| F::from(v as u64));
+                let num_bits = region.assign_advice(
+                    || "num_bits",
+                    self.num_bits,
+                    offset,
+                    || num_bits.into(),
+                )?;
+
+                // Assign value
+                let assigned_cell =
+                    region.assign_advice(|| "value", self.value, offset, || value)?;
+
+                Ok(RangeConstrained {
+                    num_bits,
+                    assigned_cell,
+                })
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use halo2_proofs::{
+        circuit::floor_planner::V1,
+        dev::{FailureLocation, MockProver, VerifyFailure},
+        pasta::Fp,
+        plonk::{Any, Circuit},
+    };
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MyCircuit<F: FieldExt, const NUM_BITS: usize, const RANGE: usize> {
+        num_bits: Value<u8>,
+        value: Value<Assigned<F>>,
+    }
+
+    impl<F: FieldExt, const NUM_BITS: usize, const RANGE: usize> Circuit<F>
+        for MyCircuit<F, NUM_BITS, RANGE>
+    {
+        type Config = RangeCheckConfig<F, NUM_BITS, RANGE>;
+        type FloorPlanner = V1;
+
+        fn without_witnesses(&self) -> Self {
+            Self::default()
+        }
+
+        fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            let num_bits = meta.advice_column();
+            let value = meta.advice_column();
+            RangeCheckConfig::configure(meta, num_bits, value)
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            config.table.load(&mut layouter)?;
+
+            config.assign(
+                layouter.namespace(|| "Assign value"),
+                self.num_bits,
+                self.value,
+            )?;
+
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_range_check_3() {
+        let k = 9;
+        const NUM_BITS: usize = 8;
+        const RANGE: usize = 256; // 8-bit value
+
+        // Successful cases
+        for num_bits in 1u8..=NUM_BITS.try_into().unwrap() {
+            for value in (1 << (num_bits - 1))..(1 << num_bits) {
+                let circuit = MyCircuit::<Fp, NUM_BITS, RANGE> {
+                    num_bits: Value::known(num_bits),
+                    value: Value::known(Fp::from(value as u64).into()),
+                };
+
+                let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+                prover.assert_satisfied();
+            }
+        }
+    }
+
+    #[cfg(feature = "dev-graph")]
+    #[test]
+    fn print_range_check_3() {
+        use plotters::prelude::*;
+
+        let root = BitMapBackend::new("range-check-3-layout.png", (1024, 3096)).into_drawing_area();
+        root.fill(&WHITE).unwrap();
+        let root = root
+            .titled("Range Check 3 Layout", ("sans-serif", 60))
+            .unwrap();
+
+        let circuit = MyCircuit::<Fp, 8, 256> {
+            num_bits: Value::unknown(),
+            value: Value::unknown(),
+        };
+        halo2_proofs::dev::CircuitLayout::default()
+            .render(9, &circuit, &root)
+            .unwrap();
+    }
+}

--- a/src/range_check/example3_broken/table.rs
+++ b/src/range_check/example3_broken/table.rs
@@ -1,0 +1,80 @@
+use std::marker::PhantomData;
+
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{Layouter, Value},
+    plonk::{ConstraintSystem, Error, TableColumn},
+};
+
+/// A lookup table of values up to RANGE
+/// e.g. RANGE = 256, values = [0..255]
+/// This table is tagged by an index `k`, where `k` is the number of bits of the element in the `value` column.
+#[derive(Debug, Clone)]
+pub(super) struct RangeTableConfig<F: FieldExt, const NUM_BITS: usize, const RANGE: usize> {
+    pub(super) num_bits: TableColumn,
+    pub(super) value: TableColumn,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt, const NUM_BITS: usize, const RANGE: usize> RangeTableConfig<F, NUM_BITS, RANGE> {
+    pub(super) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+        assert_eq!(1 << NUM_BITS, RANGE);
+
+        let num_bits = meta.lookup_table_column();
+        let value = meta.lookup_table_column();
+
+        Self {
+            num_bits,
+            value,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(super) fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+        layouter.assign_table(
+            || "load range-check table",
+            |mut table| {
+                let mut offset = 0;
+
+                // Assign (num_bits = 1, value = 0)
+                {
+                    table.assign_cell(
+                        || "assign num_bits",
+                        self.num_bits,
+                        offset,
+                        || Value::known(F::one()),
+                    )?;
+                    table.assign_cell(
+                        || "assign value",
+                        self.value,
+                        offset,
+                        || Value::known(F::zero()),
+                    )?;
+
+                    offset += 1;
+                }
+
+                for num_bits in 1..=NUM_BITS {
+                    for value in (1 << (num_bits - 1))..(1 << num_bits) {
+                        table.assign_cell(
+                            || "assign num_bits",
+                            self.num_bits,
+                            offset,
+                            || Value::known(F::from(num_bits as u64)),
+                        )?;
+                        table.assign_cell(
+                            || "assign value",
+                            self.value,
+                            offset,
+                            || Value::known(F::from(value as u64)),
+                        )?;
+                        offset += 1;
+                    }
+
+                }
+
+                Ok(())
+            },
+        )
+    }
+}


### PR DESCRIPTION
Ways to check that a value `v` is in the range `R`.

Example 1: Simple range check using an expression `v * (1 - v) * (2 - v) * ... * (R - v)`.
Example 2: Extend config to support lookup range check for larger ranges.
Example 3 (broken): Extend lookup to include a `num_bits` tag column for stricter range checks.

Task: fix the lookup argument in Example 3.